### PR TITLE
feat: Implements the parseEvent function so that it can parse a valid push event and return the corresponding CI Job.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,14 @@ repositories {
 
 dependencies {
     implementation 'javax.servlet:javax.servlet-api:4.0.1'
-    implementation 'org.eclipse.jetty:jetty-server:11.0.8'
     testImplementation 'junit:junit:4.+'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    implementation 'org.json:json:20211205'
+    implementation 'org.springframework:spring-test:5.3.15'
+    implementation 'org.eclipse.jetty:jetty-server:9.4.43.v20210629'
 }
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+
+test {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -19,3 +19,5 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/crimson/WebHookHandler.java
+++ b/src/main/java/crimson/WebHookHandler.java
@@ -1,0 +1,62 @@
+package crimson;
+import karmosin.*;
+import org.eclipse.jetty.server.Request;
+import org.json.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.util.stream.Collectors;
+
+public class WebHookHandler implements karmosin.WebHookHandler {
+
+    /**
+     * parseEvent responsible for parsing an event from the Webhook and create an
+     * ContinuousIntegrationJob object.
+     *
+     * @param target
+     * @param baseRequest
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public ContinuousIntegrationJob parseEvent(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        ContinuousIntegrationJob job = new ContinuousIntegrationJob();
+        if (request.getMethod().equals("POST")) {
+            JSONObject json = new JSONObject(request.getReader().lines().collect(Collectors.joining()));
+            String gitRef = json.getString("ref");
+            String url = json.getJSONObject("repository").getString("url");
+            URL repoUrl = new URL(url);
+            JSONArray commits = json.getJSONArray("commits");
+            JSONObject commit = commits.getJSONObject(0);
+            String commitHash = commit.getString("id");
+            String pusherName = commit.getJSONObject("author").getString("name");
+            String pusherEmail = commit.getJSONObject("author").getString("email");
+            job.gitRefs = gitRef;
+            job.repoGitUrl = repoUrl;
+            job.commitHash = commitHash;
+            job.pusherName = pusherName;
+            job.pusherEmail = pusherEmail;
+        }
+        return job;
+    }
+
+    /**
+     * responseEvent() response to an WebHook event (e.g. tell the status)
+     *
+     * @param target
+     * @param baseRequest
+     * @param request
+     * @param response
+     * @param continuousIntegrationJob
+     * @throws Exception
+     */
+    @Override
+    public void responseEvent(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response, ContinuousIntegrationJob continuousIntegrationJob) throws IOException, ServletException {
+
+    }
+}

--- a/src/test/java/WebHookHandlerTests.java
+++ b/src/test/java/WebHookHandlerTests.java
@@ -1,0 +1,50 @@
+import crimson.WebHookHandler;
+import karmosin.ContinuousIntegrationJob;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WebHookHandlerTests {
+    /**
+     * Tests the functionality of the parseEvent function when parsing push events,
+     * by feeding it a MockHttpServletRequest with a valid JSON payload.
+     */
+    @Test
+    public void validTestPushParsing() throws ServletException, IOException {
+        WebHookHandler handler = new WebHookHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        JSONObject obj = new JSONObject();
+        JSONObject repo = new JSONObject();
+        JSONObject commit = new JSONObject();
+        JSONArray commits = new JSONArray();
+        JSONObject author = new JSONObject();
+        author.put("name", "John Doe");
+        author.put("email", "123@kth.se");
+        commit.put("id", "12345");
+        commit.put("author", author);
+        commits.put(commit);
+        repo.put("url", "https://github.com/Codertocat/Hello-World");
+        obj.put("repository", repo);
+        obj.put("ref", "test_ref");
+        obj.put("after", "test_after");
+        obj.put("compare", "test_compare");
+        obj.put("commits", commits);
+        byte[] jsonBytes = obj.toString().getBytes();
+        request.setContent(jsonBytes);
+        request.setMethod("POST");
+        ContinuousIntegrationJob job = handler.parseEvent("", null, request, null);
+
+        assertEquals(job.repoGitUrl.toString(), "https://github.com/Codertocat/Hello-World");
+        assertEquals(job.gitRefs, "test_ref");
+        assertEquals(job.commitHash, "12345");
+        assertEquals(job.pusherName, "John Doe");
+        assertEquals(job.pusherEmail, "123@kth.se");
+    }
+}


### PR DESCRIPTION
Fixes #24, please also help to link this issue with the new commit from squash and merge.