### PR TITLE
fix: use String.equals() in WebHookHandler

### DIFF
--- a/src/main/java/crimson/WebHookHandler.java
+++ b/src/main/java/crimson/WebHookHandler.java
@@ -28,7 +28,7 @@ public class WebHookHandler implements karmosin.WebHookHandler {
         ContinuousIntegrationJob job = new ContinuousIntegrationJob();
         if (request.getMethod().equals("POST")) {
             JSONObject json = new JSONObject(request.getReader().lines().collect(Collectors.joining()));
-            if (json.getString("after") == "0000000000000000000000000000000000000000"){
+            if (json.getString("after").equals("0000000000000000000000000000000000000000")){
                 return null;
             }
             String gitRef = json.getString("ref");


### PR DESCRIPTION
fix #58 